### PR TITLE
added option to vtkSplineDrivenImageSlicer to choose interpolation mode

### DIFF
--- a/Filters/vtkSplineDrivenImageSlicer.cxx
+++ b/Filters/vtkSplineDrivenImageSlicer.cxx
@@ -273,7 +273,7 @@ int vtkSplineDrivenImageSlicer::RequestData(
 	 
          this->reslicer->SetResliceAxes( resliceAxes );
          this->reslicer->SetInformationInput( input );
-         this->reslicer->SetInterpolationModeToCubic( );
+         this->reslicer->SetInterpolationMode( this->InterpolationMode );
 
          this->reslicer->SetOutputDimensionality( 2 );
          this->reslicer->SetOutputOrigin(0,0,0);

--- a/Filters/vtkSplineDrivenImageSlicer.h
+++ b/Filters/vtkSplineDrivenImageSlicer.h
@@ -21,6 +21,11 @@
 
 #include"vtkImageAlgorithm.h"
 
+// interpolation mode constants
+#define VTK_RESLICE_NEAREST VTK_NEAREST_INTERPOLATION
+#define VTK_RESLICE_LINEAR VTK_LINEAR_INTERPOLATION
+#define VTK_RESLICE_CUBIC VTK_CUBIC_INTERPOLATION
+
 class vtkFrenetSerretFrame;
 class vtkImageReslice;
 
@@ -61,6 +66,17 @@ public:
    vtkSetMacro( Incidence, double );
    vtkGetMacro( Incidence, double );
 
+   // Description:
+   // Set interpolation mode (default: nearest neighbor).
+   vtkSetClampMacro(InterpolationMode, int,
+       VTK_RESLICE_NEAREST, VTK_RESLICE_CUBIC);
+   vtkGetMacro(InterpolationMode, int);
+   void SetInterpolationModeToNearestNeighbor() {
+       this->SetInterpolationMode(VTK_RESLICE_NEAREST); };
+   void SetInterpolationModeToLinear() {
+       this->SetInterpolationMode(VTK_RESLICE_LINEAR); };
+   void SetInterpolationModeToCubic() {
+       this->SetInterpolationMode(VTK_RESLICE_CUBIC); };
 
 protected:
    vtkSplineDrivenImageSlicer();
@@ -73,6 +89,9 @@ protected:
    virtual int FillOutputPortInformation( int, vtkInformation*);
    virtual int RequestInformation(vtkInformation*, vtkInformationVector**, 
 	                                                vtkInformationVector*);
+
+   int InterpolationMode;
+
 private:
    vtkSplineDrivenImageSlicer(const vtkSplineDrivenImageSlicer&);  // Not implemented.
    void operator=(const vtkSplineDrivenImageSlicer&);  // Not implemented.


### PR DESCRIPTION
This pass-through option goes to vtkImageReslice to choose its interpolation mode. This comes in handy when e.g. working with label data.